### PR TITLE
fix: explicitely name classes in super

### DIFF
--- a/src/plone/jsonapi/routes/adapters.py
+++ b/src/plone/jsonapi/routes/adapters.py
@@ -70,7 +70,7 @@ class ZCDataProvider(Base):
     component.adapts(ICatalogBrain)
 
     def __init__(self, context):
-        super(self.__class__, self).__init__(context)
+        super(ZCDataProvider, self).__init__(context)
 
     def to_dict(self):
         brain = self.context
@@ -96,7 +96,7 @@ class DexterityDataProvider(Base):
     component.adapts(IDexterityContent)
 
     def __init__(self, context):
-        super(self.__class__, self).__init__(context)
+        super(DexterityDataProvider, self).__init__(context)
 
         schema = SCHEMA_CACHE.get(context.portal_type)
         self.keys = schema.names()
@@ -109,7 +109,7 @@ class ATDataProvider(Base):
     component.adapts(IATContentType)
 
     def __init__(self, context):
-        super(self.__class__, self).__init__(context)
+        super(ATDataProvider, self).__init__(context)
         schema = context.Schema()
         self.keys = schema.keys()
 
@@ -121,7 +121,7 @@ class SiteRootDataProvider(Base):
     component.adapts(ISiteRoot)
 
     def __init__(self, context):
-        super(self.__class__, self).__init__(context)
+        super(SiteRootDataProvider, self).__init__(context)
 
 #---------------------------------------------------------------------------
 #   Functional Helpers


### PR DESCRIPTION
It allows using super in inherited classes. Illustration of the problem:

```python
class A(object):
    def __init__(self):
        pass

class B(object):
    def __init__(self):
        super(self.__class__, self).__init__()

class C(object):
    def __init__(self):
        super(C, self).__init__()

>>> C()
Infinite loop
```

`self.__class__` of C is C. Which means that when `__init__` of B is called from C, `super(self.__class__, self).__init__()` is equivalent to `super(C, self).__init__()`, and thus `__init__` of B is called again, and again, etc.