### PR TITLE
include custom metadata columns. 

### DIFF
--- a/src/plone/jsonapi/routes/docs/Readme.txt
+++ b/src/plone/jsonapi/routes/docs/Readme.txt
@@ -117,3 +117,52 @@ We can also use 'descending' sort::
     >>> response = self.decode(browser.contents)
     >>> [x['id'] for x in response.get('items')][:3]
     ['folder', 'document-49', 'document-48']
+
+
+Results data
+============
+
+What's in the result?
+
+All catalog indexes are included in results, including any custom indexes.
+The 
+   
+    >>> browser.open(api_url + "/folders")
+    >>> response = self.decode(browser.contents)
+    >>> folder = response.get("items")[0]
+    >>> keys = folder.keys()
+
+The following default metadata columns are not included, since they duplicate
+other indexes or are not really interesting outside plone.
+
+    >>> ignored_metadata = [
+    ...     'Date',
+    ...     'CreationDate',
+    ...     'EffectiveDate',
+    ...     'ExpirationDate',
+    ...     'ModificationDate',
+    ...     'cmf_uid',
+    ...     'getObjSize',
+    ...     'getIcon'
+    ...     'id',
+    ...     'is_folderish',
+    ...     'meta_type',
+    ...     'Type',
+    ... ]
+    >>> filter(lambda k: k in ignored_metadata, keys)
+    []
+
+Some builtin metadata columns are mapped to simplified, lower case keys.
+
+    >>> mapped_metadata = ['id', 'uid', 'title', 'description', 'url', 'type', 'tags']
+    >>> filter(lambda k: k in keys, mapped_metadata)
+    ['id', 'uid', 'title', 'description', 'url', 'type', 'tags']
+
+Custom indexes are included
+
+    >>> folder['title_or_id']
+    'Test Folder'
+
+    
+    
+

--- a/src/plone/jsonapi/routes/tests/base.py
+++ b/src/plone/jsonapi/routes/tests/base.py
@@ -40,6 +40,11 @@ class TestLayer(PloneSandboxLayer):
     def setUpPloneSite(self, portal):
         setRoles(portal, TEST_USER_ID, ['Manager'])
 
+        # add a custom metadata column to portal_catalog so
+        # we can test it gets included in json output
+        portal.portal_catalog.addColumn('title_or_id')
+        portal.portal_catalog.refreshCatalog(clear=0)
+
         # add a folder, so we can test with it
         _ = portal.invokeFactory("Folder", "folder", title="Test Folder")
         folder = portal[_]
@@ -49,7 +54,6 @@ class TestLayer(PloneSandboxLayer):
         # Test fixture -- p.j.c. needs to have a request
         from plone.jsonapi.core import router
         router.DefaultRouter.initialize(portal, portal.REQUEST)
-
 
 TEST_FIXTURE = TestLayer()
 INTEGRATION_TESTING = IntegrationTesting(bases=(TEST_FIXTURE,),


### PR DESCRIPTION
Change data provider for brains to include all metadata except for certain plone standard metadata. Note this is an api change from including a specific set. This change only adds additional data in json output however. 
Is this an acceptable change?