### PR TITLE
api routes: sharing

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -126,6 +126,8 @@ Beside the *content resources*, there are some special resources available.
 +----------+--------------------+----------------------------------------+
 | login    |                    | Login with __ac_name and __ac_password |
 +----------+--------------------+----------------------------------------+
+| sharing  |                    | Resource for accesing sharing rights   |
++----------+--------------------+----------------------------------------+
 
 
 .. _Parameters:
@@ -175,6 +177,9 @@ All content resources accept to be filtered by request parameters.
 | recent_modified | today, yesterday      | Specify a recent modified date range, to find all items modified within |
 |                 | this-week, this-month | this date range until today.                                            |
 |                 | this-year             | This uses internally `'range': 'min'` query.                            |
++-----------------+-----------------------+-------------------------------------------------------------------------+
+| sharing         | yes/y/1/True          | Flag to include the sharing rights. Only visible if complete flag is    |
+|                 |                       | true.                                                                   |
 +-----------------+-----------------------+-------------------------------------------------------------------------+
 
 

--- a/src/plone/jsonapi/routes/api.py
+++ b/src/plone/jsonapi/routes/api.py
@@ -12,6 +12,9 @@ from Products.CMFCore.interfaces import IFolderish
 from Products.ZCatalog.interfaces import ICatalogBrain
 from Products.CMFPlone.PloneBatch import Batch
 
+from zope.interface import alsoProvides
+from plone.protect.interfaces import IDisableCSRFProtection
+
 # search helpers
 from query import search
 from query import make_query
@@ -308,6 +311,70 @@ def paste_items(portal_type=None, request=None, uid=None, endpoint=None):
 
 
 # -----------------------------------------------------------------------------
+#   Sharing Functions
+# -----------------------------------------------------------------------------
+
+def get_sharing(request=None, uid=None):
+    """ get sharing
+    """
+
+    # try to find the requested objects
+    objects = find_objects(uid=uid)
+
+    # No objects could be found, bail out
+    if not objects:
+        raise APIError(404, "No Objects could be found")
+
+    # We support only one sharing for time
+    if len(objects) > 1:
+        raise APIError(400, "Can only get sharing for one object at a time")
+
+    def info_sharing_from_object(obj):
+        info = get_info(obj)
+        sharing = get_sharing_info(obj)
+        info.update({'sharing': sharing})
+        return info
+
+    info = map(info_sharing_from_object, objects)
+    return info
+
+
+def update_sharing(request=None, uid=None):
+    """ set sharing
+    """
+    # try to find the requested objects
+    objects = find_objects(uid=uid)
+
+    # No objects could be found, bail out
+    if not objects:
+        raise APIError(404, "No Objects could be found")
+
+    # We support only one sharing for time
+    if len(objects) > 1:
+        raise APIError(400, "Can only get sharing for one object at a time")
+
+    # Disable CSRF for sharing view
+    alsoProvides(request, IDisableCSRFProtection)
+
+    obj = get_object(objects[0])
+    sharing = ploneapi.content.get_view('sharing', obj, req.get_request())
+
+    inherit = req.get_json_key('inherit', None)
+    if inherit is not None:
+        sharing.update_inherit(inherit)
+
+    # NOTE: role_settings is a list of dicts with keys id, for the user/group
+    # id; type, being either 'user' or 'group'; and roles, containing A LIST
+    # of role ids that are set.
+    role_settings = req.get_json_key('role_settings', None)
+    if role_settings is not None:
+        sharing.update_role_settings(role_settings)
+
+    info = get_sharing(request, uid)
+    return info
+
+
+# -----------------------------------------------------------------------------
 #   Data Functions
 # -----------------------------------------------------------------------------
 
@@ -395,6 +462,12 @@ def get_info(brain_or_object, endpoint=None, complete=False):
         if req.get_workflow(False):
             workflow = get_workflow_info(obj)
             info.update({"workflow": workflow})
+
+        # add sharing data if the user requested it
+        # -> only possible if `?complete=yes`
+        if req.get_sharing(False):
+            sharing = get_sharing_info(obj)
+            info.update({"sharing": sharing})
 
     return info
 
@@ -543,6 +616,23 @@ def get_children_info(brain_or_object, complete=False):
     return {
         "children_count": len(items),
         "children": items
+    }
+
+
+def get_sharing_info(brain_or_object):
+    """Generate sharing info of the given object
+
+    :param brain_or_object: A single catalog brain or content object
+    :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
+    :returns: sharing information of the object
+    :rtype: dict
+    """
+    obj = get_object(brain_or_object)
+    sharing = ploneapi.content.get_view('sharing', obj, req.get_request())
+
+    return {
+        "role_settings": sharing.role_settings(),
+        "inherit": sharing.inherited()
     }
 
 

--- a/src/plone/jsonapi/routes/providers/sharing.py
+++ b/src/plone/jsonapi/routes/providers/sharing.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+from plone.jsonapi.routes import add_plone_route as route
+
+# Sharing
+from plone.jsonapi.routes.api import get_sharing
+from plone.jsonapi.routes.api import update_sharing
+
+from plone.jsonapi.routes.api import url_for
+
+
+# GET
+@route("/sharing", "sharing_get", methods=["GET"])
+@route("/sharing/<string:uid>", "sharing_get", methods=["GET"])
+def get(context, request, uid=None):
+    """ get sharing
+    """
+    items = get_sharing(request, uid)
+    return {
+        "url": url_for("sharing"),
+        "count": len(items),
+        "items": items,
+    }
+
+
+# UPDATE
+@route("/sharing/update", "sharing_update", methods=["POST"])
+@route("/sharing/update/<string:uid>", "sharing_update",
+       methods=["POST"])
+def update(context, request, uid=None):
+    """ update todos
+    """
+    items = update_sharing(request=request, uid=uid)
+    return {
+        "url": url_for("sharing_update"),
+        "count": len(items),
+        "items": items,
+    }

--- a/src/plone/jsonapi/routes/request.py
+++ b/src/plone/jsonapi/routes/request.py
@@ -82,6 +82,17 @@ def get_workflow(default=None):
     return False
 
 
+def get_sharing(default=None):
+    """ returns the 'sharing' from the request
+    """
+    sharing = get("sharing", default)
+    if sharing is default:
+        return default
+    if sharing.lower() in ["y", "yes", "1", "true"]:
+        return True
+    return False
+
+
 def get_sort_limit():
     """ returns the 'sort_limit' from the request
     """

--- a/src/plone/jsonapi/routes/tests/test_api.py
+++ b/src/plone/jsonapi/routes/tests/test_api.py
@@ -125,6 +125,17 @@ class TestAPI(APITestCase):
         # should contain 50 documents
         self.assertEqual(len(children), 50)
 
+    def test_get_sharing_info(self):
+        # returns brain data
+        brain = self.get_document_brain()
+        sharing = api.get_sharing_info(brain)
+        # default sharing, inherit: true
+        self.assertTrue(sharing['inherit'])
+        # default sharing, one role setting for authenticated users
+        self.assertEqual(
+            sharing['role_settings'][0]['id'],
+            'AuthenticatedUsers')
+
     # -----------------------------------------------------------------------------
     #   Test Functional Helpers
     # -----------------------------------------------------------------------------


### PR DESCRIPTION
Done:

* Created sharing routes for `GET` and `UPDATE` sharing roles for an item, given its UID.
* Added a sharing option to `get_info` to get the sharing roles. It only works if complete=true.
* Added a `get_sharing` function in request.py.
* Added documentation for sharing functionality.
* Added test for `get_sharing_info`.
