### PR TITLE
Adds 'author' to response.

### DIFF
--- a/src/plone/jsonapi/routes/adapters.py
+++ b/src/plone/jsonapi/routes/adapters.py
@@ -55,6 +55,7 @@ class Base(object):
             "effective":   "effective",
             "portal_type": "portal_type",
             "tags":        "Subject",
+            "author":      "Creator",
         }
 
     def to_dict(self):


### PR DESCRIPTION
**Sumarry**

Adds a filed `author` to JSON response with value `Creator`.

**Rationale**

`author` is required to uniquely identify the content creator. This is useful in the client side to, for example, retrieve more information from the user, like his credentials of portrait.

**Side Note**

Merry Christmas.