### PR TITLE
Removes 'sharing' in api's special resource documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -126,8 +126,6 @@ Beside the *content resources*, there are some special resources available.
 +----------+--------------------+----------------------------------------+
 | login    |                    | Login with __ac_name and __ac_password |
 +----------+--------------------+----------------------------------------+
-| sharing  |                    | Resource for accessing sharing rights  |
-+----------+--------------------+----------------------------------------+
 
 
 .. _Parameters:


### PR DESCRIPTION
Removes reference to deprecated route 'sharing' from api documentation, section "Special Resources".