### PR TITLE
Using specifiers to format string

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/HISTORY.rst merge=union

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -3,6 +3,12 @@
 Changelog
 =========
 
+0.8.x - Unreleased
+------------------
+
+- Using specifiers to format string (helps compatibility with Python 2.6,
+  improves code readability)
+  [ale-rt]
 
 0.8.4 - 2016-01-14
 ------------------

--- a/src/plone/jsonapi/routes/adapters.py
+++ b/src/plone/jsonapi/routes/adapters.py
@@ -304,11 +304,16 @@ def get_download_url(obj, fieldname, field=_marker, default=None):
     if is_dexterity_content(obj):
         # calculate the download url
         filename = getattr(field, "filename", "")
-        download = "{}/@@download/{}/{}".format(
-            obj.absolute_url(), fieldname, filename)
+        download = "{url}/@@download/{fieldname}/{filename}".format(
+            url=obj.absolute_url(),
+            fieldname=fieldname,
+            filename=filename,
+        )
     else:
         # calculate the download url
-        download = "{}/download".format(obj.absolute_url())
+        download = "{url}/download".format(
+            url=obj.absolute_url(),
+        )
     return download
 
 


### PR DESCRIPTION
It keeps the code Python2.6 compatible
and improves code readability