### PR TITLE
Fixes https://github.com/collective/plone.jsonapi.routes/issues/62: '…

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -6,6 +6,7 @@ Changelog
 0.8.5 - unreleased
 ------------------
 
+- https://github.com/collective/plone.jsonapi.routes/issues/62: 'reference_catalog' not found
 - Reuse and improve code to check if a parameter in the request
   has a True value
 - Using specifiers to format string (helps compatibility with Python 2.6,

--- a/src/plone/jsonapi/routes/api.py
+++ b/src/plone/jsonapi/routes/api.py
@@ -13,6 +13,7 @@ from Products.CMFCore.interfaces import IFolderish
 from Products.ZCatalog.interfaces import ICatalogBrain
 from Products.CMFPlone.PloneBatch import Batch
 from Products.CMFPlone.interfaces import IConstrainTypes
+from plone.api.exc import InvalidParameterError
 
 # search helpers
 from query import search
@@ -662,9 +663,12 @@ def get_portal_reference_catalog():
     """Get the portal reference catalog tool
 
     :returns: Portal Reference Catalog Tool
-    :rtype: object
+    :rtype: object | None
     """
-    return get_tool("reference_catalog")
+    try:
+        return get_tool("reference_catalog")
+    except InvalidParameterError:
+        return None
 
 
 def get_portal_workflow():
@@ -1014,7 +1018,7 @@ def get_object_by_uid(uid):
     rc = get_portal_reference_catalog()
 
     # try to find the object with the reference catalog first
-    obj = rc.lookupObject(uid)
+    obj = rc and rc.lookupObject(uid)
     if obj:
         return obj
 

--- a/src/plone/jsonapi/routes/tests/test_api.py
+++ b/src/plone/jsonapi/routes/tests/test_api.py
@@ -154,9 +154,14 @@ class TestAPI(APITestCase):
             getToolByName(self.portal, "portal_catalog"))
 
     def test_get_portal_reference_catalog(self):
+        try:
+            rc = getToolByName(self.portal, "reference_catalog")
+        except AttributeError:
+            rc = None
+
         self.assertEqual(
             api.get_portal_reference_catalog(),
-            getToolByName(self.portal, "reference_catalog"))
+            rc)
 
     def test_get_portal_workflow(self):
         self.assertEqual(


### PR DESCRIPTION
This could fix https://github.com/collective/plone.jsonapi.routes/issues/62

I didn't test it on plone 5, so I was unable to reproduce the bug, but since its cause is the absence of reference_catalog tool, if get_reference_catalog is allowed to return None, and its callers deal with it, then it'll fix it.